### PR TITLE
Sort files where order is significant

### DIFF
--- a/src/Localization.cpp
+++ b/src/Localization.cpp
@@ -10,6 +10,7 @@ void Localization::LoadLocalsFromFolder(std::string folder, Fonts *fonts)
 {
 	fonts_ptr = fonts;
 	std::vector<fs::path> files = GetFilesInFolder(folder, ".loc");
+	sort(files.begin(), files.end());
 	for (int i = 0; i < files.size(); i++)
 	{
 		LoadLocalFromFile(files[i]);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -22,6 +22,7 @@ Renderer::Renderer()
 void Renderer::LoadConfigs(std::string config_file)
 {
 	std::vector<fs::path> configs = GetFilesInFolder(fs::path(config_file).parent_path().string(), ".cfg");
+	sort(configs.begin(), configs.end());
 	for (auto &file : configs)
 	{
 		rendering_configurations.push_back(file.filename().string());


### PR DESCRIPTION
There are, as far as I can tell, two occasions where the order of files in the directory matters.
This concerns the files of which only the index is stored. More specifically, this concerns the locale and the render config.
Performing a simple `sort` on the vector makes it behave uniformly on all platforms.

A problem that I encountered and may arise for other users is that the default configuration does not reflect its original meaning when the order of iteration of the locales or render configs directories is not consistent between the original author's and of the executing platform.

For me, this meant that the default language was Japanese and that the default render config was `ORIGINAL.cfg`. This should obviously not be happening.

Discovered this bug while writing an AUR package.