### PR TITLE
Fix a few random bugs and warnings.

### DIFF
--- a/src/ExprParser.cpp
+++ b/src/ExprParser.cpp
@@ -275,6 +275,7 @@ int ExprParser::getOperatorPrecedenceLevel(int op)
 		return 5;
 	else if (op == LBRACK)
 		return 6;
+	return !0; // impossible case
 }
 
 //get operator id from the token
@@ -418,7 +419,7 @@ void ExprParser::Parse(std::string expr)
 float ExprParser::Evaluate(std::map<std::string, float> variable_map)
 {	
 	variable_map["pi"] = 3.141592653589f;
-	variable_map["e"] == 2.718281828459f;	
+	variable_map["e"]  = 2.718281828459f;	
 
 	//code written in such a way to be compatible with OpenCL
 	float varstack[64];

--- a/src/Shaders.cpp
+++ b/src/Shaders.cpp
@@ -212,7 +212,7 @@ std::string ComputeShader::PreprocessIncludes(const fs::path& filename, int leve
 	using namespace std;
 
 	//match regular expression
-	static const regex re("^[ ]*#include\s*[\"<](.*)[\">].*");
+	static const regex re("^[ ]*#include\\s*[\"<](.*)[\">].*");
 	stringstream input;
 	stringstream output;
 	input << LoadFileText(filename);


### PR DESCRIPTION
An `==` where there should be an `=`, a `\` where there should be a `\\`, and a  function that was UB if called incorrectly.