### PR TITLE
Fix Screenshots

### DIFF
--- a/src/Gamemodes.cpp
+++ b/src/Gamemodes.cpp
@@ -1,5 +1,6 @@
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "Gamemodes.h"
-
 
 //Global variables
 sf::Vector2i mouse_pos, mouse_prev_pos;
@@ -23,6 +24,7 @@ Renderer *renderer_ptr;
 sf::RenderWindow *window;
 GLuint *main_txt, *screenshot_txt;
 GLuint *framebuffer;
+GLubyte *screenshot_data;
 
 void SetPointers(sf::RenderWindow *w, Scene* scene, Overlays* overlays, Renderer* rd, GLuint *main, GLuint *screensht, GLuint *fb)
 {
@@ -954,26 +956,27 @@ void TakeScreenshot()
 	renderer_ptr->ReInitialize(screenshot_resolution.x, screenshot_resolution.y);
 
 	scene_ptr->WriteRenderer(*renderer_ptr);
-	renderer_ptr->SetOutputTexture(*screenshot_txt);
+	renderer_ptr->SetOutputTexture(*screenshot_txt, *framebuffer);
 
 	renderer_ptr->camera.SetMotionBlur(0);
-/*
-	std::vector<char> buffer(screenshot_resolution.x * screenshot_resolution.y * 4);
+
+	screenshot_data = new GLubyte[screenshot_resolution.x * screenshot_resolution.y * 4];
 	std::string filename = (std::string)"screenshots/screenshot" + (std::string)num2str(time(NULL)) + (std::string)".jpg";
 	
 	//a few rendering steps to converge the TXAA
 	for(int i = 0; i < SETTINGS.stg.screenshot_samples; i++) 	renderer_ptr->Render();
 	window -> resetGLStates();
 
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, *framebuffer);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    glBlitFramebuffer(screenshot_resolution.x, 0, 0, screenshot_resolution.y, screenshot_resolution.x, screenshot_resolution.y, 0, 0, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
-	glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA8, GL_UNSIGNED_BYTE, buffer.data());
+	glReadPixels(0, 0, screenshot_resolution.x, screenshot_resolution.y, GL_RGBA, GL_UNSIGNED_BYTE, screenshot_data);
 
-	stbi_flip_vertically_on_write(true);
-	stbi_write_jpg(filename.c_str(), screenshot_resolution.x, screenshot_resolution.y, 3, buffer.data(), 100);
-*/
+	stbi_write_jpg(filename.c_str(), screenshot_resolution.x, screenshot_resolution.y, 4, screenshot_data, 100);
+
 	scene_ptr->SetResolution(rendering_resolution.x, rendering_resolution.y);
 	renderer_ptr->ReInitialize(rendering_resolution.x, rendering_resolution.y);
-	renderer_ptr->SetOutputTexture(*main_txt);
 	overlays_ptr->sound_screenshot.play();
 	screenshot_clock.restart();
 }
@@ -1020,9 +1023,7 @@ void InitializeRendering(std::string config)
 
 	glDeleteTextures(1, screenshot_txt);
 	glCreateTextures(GL_TEXTURE_2D, 1, screenshot_txt);
-	glTextureStorage2D(*main_txt, 1, GL_RGBA8, screenshot_resolution.x, screenshot_resolution.y);
-
-	renderer_ptr->SetOutputTexture(*main_txt);
+	glTextureStorage2D(*screenshot_txt, 1, GL_RGBA8, screenshot_resolution.x, screenshot_resolution.y);
 }
 
 void SetCameraFocus(float f)
@@ -1147,8 +1148,6 @@ void TW_CALL ApplySettings(void *data)
 	std::vector<std::string> configs = renderer_ptr->GetConfigurationsList();
 
 	InitializeRendering(configs[SETTINGS.stg.shader_config]);
-
-	glNamedFramebufferTexture(*framebuffer, GL_COLOR_ATTACHMENT0, *main_txt, 0);
 
 	if (game_mode == LEVEL_EDITOR)
 		SetCameraFocus(1e10);

--- a/src/Gamemodes.h
+++ b/src/Gamemodes.h
@@ -1,8 +1,6 @@
 #pragma once
 
-/*#define STB_IMAGE_IMPLEMENTATION
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#include <stb/stb_image_write.h>*/
+#include <stb/stb_image_write.h>
 
 #include<config.h>
 #include<Overlays.h>
@@ -38,6 +36,7 @@ extern bool show_cheats;
 extern bool taken_screenshot;
 extern sf::Clock screenshot_clock;
 extern InputState io_state;
+extern GLubyte *screenshot_data;
 
 //Constants
 extern float target_fps;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -680,10 +680,9 @@ int main(int argc, char *argv[]) {
 			{
 				if (!(taken_screenshot && SETTINGS.stg.screenshot_preview))
 				{
-					glNamedFramebufferTexture(framebuffer, GL_COLOR_ATTACHMENT0, main_txt, 0);
+					rend.SetOutputTexture(main_txt, framebuffer);
 					scene.WriteRenderer(rend);
 					rend.camera.SetAspectRatio((float)window.getSize().x / (float)window.getSize().y);
-					rend.SetOutputTexture(main_txt);
 					//Draw to the render texture
 					rend.Render();
 					window.resetGLStates();
@@ -694,20 +693,23 @@ int main(int argc, char *argv[]) {
 				}
 				else
 				{
-/*					//Draw screenshot preview
-					sf::Sprite sprite(screenshot_txt);
-					sf::Vector2u ssize = screenshot_txt.getSize();
+					//Draw screenshot preview
+					sf::Vector2u ssize = (sf::Vector2u)getResolution(SETTINGS.stg.screenshot_resolution);
+					sf::Image image(ssize, (std::uint8_t*)screenshot_data);
+					sf::Texture texture(image);
+					sf::Sprite sprite(texture);
 					float scale = min(float(window.getSize().x) / float(ssize.x),
 						float(window.getSize().y) / float(ssize.y));
 					vec2 pos = vec2(window.getSize().x - ssize.x*scale, window.getSize().y - ssize.y*scale)*0.5f;
 					sprite.setScale(sf::Vector2f(scale, scale));
 					sprite.setPosition(sf::Vector2f(pos.x, pos.y));
 					window.draw(sprite);
-*/
+
 					const float s = screenshot_clock.getElapsedTime().asSeconds();
 					if (s > SETTINGS.stg.preview_time)
 					{
 						taken_screenshot = false;
+						free(screenshot_data);
 					}
 				}
 			}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -228,9 +228,10 @@ void Renderer::ReInitialize(int w, int h)
 }
 
 
-void Renderer::SetOutputTexture(GLuint tex)
+void Renderer::SetOutputTexture(GLuint tex, GLuint fb)
 {
 	shader_textures[shader_textures.size()-1][0] = tex;
+	glNamedFramebufferTexture(fb, GL_COLOR_ATTACHMENT0, tex, 0);
 }
 
 void Renderer::LoadShader(std::string shader_file)

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -34,7 +34,7 @@ public:
 	void Initialize(int w, int h, std::string config = "");
 	void ReInitialize(int w, int h);
 
-	void SetOutputTexture(GLuint tex);
+	void SetOutputTexture(GLuint tex, GLuint fb);
 	void LoadShader(std::string shader_file);
 	std::vector<std::string> GetConfigurationsList();
 	std::string GetConfigFolder();


### PR DESCRIPTION
Uses [stb](https://github.com/nothings/stb/blob/master/stb_image_write.h) to save the screenshots as jpg. Tested on Debian Forky. Might be worth adding stb_image_write.h into the repo so people don't have to go out getting it.

Example Screenshot:
<img width="1600" height="900" alt="screenshot1777669594" src="https://github.com/user-attachments/assets/e51610f7-bcfe-4022-9a25-ece6c6d502ad" />
